### PR TITLE
Add support for XFS and update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In its current state, this script leverages common Linux utilities (gdisk, qemu-
 * Supports multiple VM disk formats (qcow2, vmdk)
 * Automatic detection and mounting of common filesystems:
   * Windows (NTFS)
-  * Linux (ext4, ZFS, BTRFS)
+  * Linux (ext3, ext4, xfs, ZFS, BTRFS)
   * macOS (HFS+, APFS)
   * BSD (ZFS)
 * Safe, non-destructive SBOM generation using Syft

--- a/sbom-vm.py
+++ b/sbom-vm.py
@@ -173,7 +173,7 @@ class ImageMounter:
                 # Find filesystem type - it's usually after the size
                 fs_type = ''
                 for i, part in enumerate(parts):
-                    if part.lower() in ['ext3', 'ext4', 'ntfs', 'hfsplus', 'apfs', 'fat32', 'vfat', 'btrfs']:
+                    if part.lower() in ['ext3', 'ext4', 'xfs', 'ntfs', 'hfsplus', 'apfs', 'fat32', 'vfat', 'btrfs']:
                         fs_type = part.lower()
                         break
                 
@@ -197,11 +197,12 @@ class ImageMounter:
                     continue
                 
                 # Check filesystem type
-                if fs_type and fs_type.lower() in ['ntfs', 'hfsplus', 'apfs', 'ext3', 'ext4', 'vfat', 'fat32', 'btrfs']:
+                if fs_type and fs_type.lower() in ['ntfs', 'hfsplus', 'apfs', 'ext3', 'ext4', 'xfs', 'vfat', 'fat32', 'btrfs']:
                     # Assign priority based on filesystem type
                     priority = {
                         'ext4': 3,    # Highest priority for Linux root
                         'ext3': 3,    # High priority for Linux
+                        'xfs': 3,     # High priority for Linux
                         'btrfs': 3,   # High priority for Linux root
                         'ntfs': 2,    # High priority for Windows
                         'hfsplus': 2, # High priority for macOS
@@ -218,9 +219,9 @@ class ImageMounter:
                         blkid_result = self._run_command(["blkid", partition], check=False)
                         if blkid_result.returncode == 0:
                             blkid_output = blkid_result.stdout.lower()
-                            for fs in ['ntfs', 'hfsplus', 'apfs', 'ext4', 'ext3', 'vfat', 'zfs_member', 'btrfs']:
+                            for fs in ['ntfs', 'hfsplus', 'apfs', 'ext4', 'ext3', 'xfs', 'vfat', 'zfs_member', 'btrfs']:
                                 if fs in blkid_output:
-                                    priority = 3 if fs in ['ext4', 'ext3', 'btrfs'] else 2 if fs in ['ntfs', 'hfsplus', 'apfs'] else 1
+                                    priority = 3 if fs in ['ext4', 'ext3', 'xfs', 'btrfs'] else 2 if fs in ['ntfs', 'hfsplus', 'apfs'] else 1
                                     partitions.append((partition, fs, size, priority))
                                     logger.info(f"Found usable partition {partition} of type {fs} (via blkid)")
                                     break

--- a/sbom-vm.py
+++ b/sbom-vm.py
@@ -267,6 +267,9 @@ class ImageMounter:
             self._run_command(["modprobe", "apfs"], check=False)
             mount_opts = ["mount", "-t", "apfs", "-o", "ro"]
             self._run_command(mount_opts + [self.mounted_partition, str(self.mount_point)])
+        elif fs_type == "xfs":
+            mount_opts = ["mount", "-t", "xfs", "-o", "ro,norecovery"]
+            self._run_command(mount_opts + [self.mounted_partition, str(self.mount_point)])
         else:
             mount_opts = ["mount", "-o", "ro"]
             if fs_type in ["ntfs", "vfat", "ufs"]:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add XFS support for partition detection and safe mounting so XFS Linux images work reliably for SBOM generation. Updated the README to include XFS.

- **New Features**
  - Detect XFS via `lsblk` and `blkid`, and prioritize it like ext3/ext4/btrfs.
  - Mount XFS read-only with `norecovery` to avoid failures with dirty logs (common in VM snapshots).
  - Update README to list `ext3`, `ext4`, and `xfs` under supported Linux filesystems.

<sup>Written for commit 5bb6b9ce3088703f6f11e9cec152a8387953418c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

