### PR TITLE
Fix Repo Assist scheduled PR check auth

### DIFF
--- a/.github/workflows/repo-assist.lock.yml
+++ b/.github/workflows/repo-assist.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"53c7d45142c93e05705a2d1cf761b8cf7ac0cf6bfa88307052908d3af395e689","body_hash":"cdde39d1b479755a2293a3c7fc300b0c1e886a21d6034dd9fc6c7c392954e0fe","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot","agent_model":"gpt-5-mini"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"b7077ff55270ca3092f4865aa10ec7c7570ae060d44b260c1957ed2b100ab542","body_hash":"cdde39d1b479755a2293a3c7fc300b0c1e886a21d6034dd9fc6c7c392954e0fe","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot","agent_model":"gpt-5-mini"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -94,6 +94,8 @@ on:
   - cron: "6 */12 * * *"
   # steps: # Steps injected into pre-activation job
   # - id: check
+    # env:
+      # GH_TOKEN: ${{ github.token }}
     # run: |
       # MAX_OPEN_PRS=8
       # if [[ "$GITHUB_EVENT_NAME" != "schedule" ]]; then exit 0; fi
@@ -1869,6 +1871,8 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_command_position.cjs');
             await main();
       - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           MAX_OPEN_PRS=8
           if [[ "$GITHUB_EVENT_NAME" != "schedule" ]]; then exit 0; fi
@@ -2110,4 +2114,3 @@ jobs:
             /tmp/gh-aw/safe-output-items.jsonl
             /tmp/gh-aw/temporary-id-map.json
           if-no-files-found: ignore
-

--- a/.github/workflows/repo-assist.md
+++ b/.github/workflows/repo-assist.md
@@ -32,6 +32,8 @@ on:
     pull-requests: read
   steps:
     - id: check
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         MAX_OPEN_PRS=8
         if [[ "$GITHUB_EVENT_NAME" != "schedule" ]]; then exit 0; fi


### PR DESCRIPTION
## Summary

- set `GH_TOKEN` for the Repo Assist pre-activation `gh pr list` check
- update the compiled workflow metadata so the lock file stays current

## Validation

- `gh aw compile --no-emit`
- parsed `.github/workflows/repo-assist.lock.yml` with Python YAML
- reproduced the formerly failing `gh pr list` command locally with `GH_TOKEN` set


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the scheduled Repo Assist PR check by setting an auth token so `gh pr list` runs authenticated and stops failing on schedule. Also refreshes the compiled workflow metadata to keep the lock file current.

- **Bug Fixes**
  - Set `GH_TOKEN: ${{ github.token }}` in the pre-activation check step (source and lock) so `gh pr list` authenticates during scheduled runs.

<sup>Written for commit 2645a2c5cf058d4eb067cbffaf4c23f1bc1b7572. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/popey/sbom-vm/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

