### PR TITLE
Consolidate repo-assist cleanup fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Compile scripts
+        run: python -m py_compile sbom-vm.py generate-test-images.py
+      - name: Run unit tests
+        run: python -m unittest discover -s tests

--- a/.github/workflows/repo-assist.lock.yml
+++ b/.github/workflows/repo-assist.lock.yml
@@ -90,8 +90,6 @@ on:
     types:
     - created
     - edited
-  schedule:
-  - cron: "6 */12 * * *"
   # steps: # Steps injected into pre-activation job
   # - id: check
     # env:

--- a/.github/workflows/repo-assist.md
+++ b/.github/workflows/repo-assist.md
@@ -17,7 +17,6 @@ description: |
   Always polite, constructive, and mindful of the project's goals.
 
 on:
-  schedule: every 12h
   workflow_dispatch:
     inputs:
       command:
@@ -83,16 +82,16 @@ safe-outputs:
     title-prefix: "[repo-assist] "
     labels: [automation, repo-assist]
     protected-files: fallback-to-issue
-    max: 4
+    max: 1
   push-to-pull-request-branch:
     target: "*"
     required-title-prefix: "[repo-assist] "
-    max: 4
+    max: 1
     protected-files: fallback-to-issue
   create-issue:
     title-prefix: "[repo-assist] "
     labels: [automation, repo-assist]
-    max: 4
+    max: 1
   update-issue:
     target: "*"
     required-title-prefix: "[repo-assist] "

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing to sbom-vm
+
+Thanks for helping improve sbom-vm.
+
+- Open an issue before larger behavior changes so the approach can be discussed.
+- Keep pull requests focused on one concern.
+- Include tests when the change can be tested without root, Docker, loop devices, or real disk images.
+- Run `python -m py_compile sbom-vm.py generate-test-images.py` and `python -m unittest discover -s tests` before submitting code.
+- Mention related issues in the PR body, for example `Closes #10`.

--- a/generate-test-images.py
+++ b/generate-test-images.py
@@ -8,7 +8,7 @@ import logging
 import shutil
 import time
 import tempfile
-from typing import Optional, List, Dict
+from typing import Optional, List
 
 # Get the directory where the script is located
 SCRIPT_DIR = Path(os.path.dirname(os.path.abspath(__file__)))
@@ -72,6 +72,8 @@ class TestImageGenerator:
     def __init__(self, output_dir: str = "test_images"):
         self.output_dir = SCRIPT_DIR / output_dir
         self.logger = logging.getLogger(__name__)
+        self.zfs_pool_name = None
+        self.zfs_altroot = None
         self.verify_commands()
         
         # Create output directory safely
@@ -142,7 +144,8 @@ class TestImageGenerator:
 
     def create_raw_disk(self, size_mb: int = 1024) -> Path:
         """Create an empty raw disk image using fallocate."""
-        image_path = Path(tempfile.mktemp(prefix="disk_", suffix=".raw", dir=str(self.output_dir)))
+        with tempfile.NamedTemporaryFile(prefix="disk_", suffix=".raw", dir=str(self.output_dir), delete=False) as image_file:
+            image_path = Path(image_file.name)
         
         self.logger.info(f"Creating {size_mb}MB raw disk image at {image_path}")
         self._run_command([
@@ -223,8 +226,8 @@ class TestImageGenerator:
                 for pool in pools.stdout.strip().split('\n'):
                     pool_name = pool.strip()
                     
-                    # Only cleanup pools we created (sbomtmp prefix)
-                    if pool_name.startswith("sbomtmp"):
+                    # Only clean up the pool created by this run.
+                    if self.zfs_pool_name and pool_name == self.zfs_pool_name:
                         self.logger.info(f"Cleaning up ZFS pool {pool_name}")
                         
                         try:
@@ -253,6 +256,10 @@ class TestImageGenerator:
 
         except Exception as e:
             self.logger.warning(f"Error during ZFS cleanup: {e}")
+        finally:
+            if self.zfs_altroot:
+                shutil.rmtree(self.zfs_altroot, ignore_errors=True)
+                self.zfs_altroot = None
 
     def _pool_exists(self, pool_name: str) -> bool:
         """Check if a ZFS pool exists."""
@@ -335,10 +342,6 @@ class TestImageGenerator:
             temp_dir_path = Path(temp_dir)
             mount_point = temp_dir_path / "mnt"
             
-            # Change to temp directory to avoid busy mount point issues
-            original_dir = os.getcwd()
-            os.chdir(temp_dir)
-            
             try:
                 # Create and partition raw disk
                 raw_image = self.create_raw_disk()
@@ -368,9 +371,6 @@ class TestImageGenerator:
                     if not self._ensure_loop_detached(loop_device):
                         raise RuntimeError(f"Failed to detach loop device {loop_device}")
                 
-                # Return to original directory before conversion
-                os.chdir(original_dir)
-                
                 # Convert to qcow2
                 qcow2_image = self.convert_to_qcow2(raw_image)
                 final_path = self.output_dir / f"{safe_name}.qcow2"
@@ -383,7 +383,6 @@ class TestImageGenerator:
                 
             except Exception as e:
                 self.logger.error(f"Failed during image generation: {str(e)}")
-                os.chdir(original_dir)
                 raise
 
     def create_filesystems(self, loop_device: str, fs_type: str):
@@ -394,8 +393,10 @@ class TestImageGenerator:
         
         if fs_type == "zfs":
             # Create a ZFS pool and filesystem structure with safeguards
-            pool_name = "sbomtmp"  # Unique name to avoid conflicts
-            altroot = "/tmp/sbom_zfs_tmp"  # Isolated mount point
+            pool_name = f"sbomtmp_{os.getpid()}_{int(time.time())}"
+            altroot = Path(tempfile.mkdtemp(prefix="sbom_zfs_"))
+            self.zfs_pool_name = pool_name
+            self.zfs_altroot = altroot
             
             # Create altroot directory
             os.makedirs(altroot, exist_ok=True)
@@ -405,7 +406,7 @@ class TestImageGenerator:
                 self._run_command([
                     "zpool", "create", "-f",
                     "-o", "ashift=12",     # Proper alignment for modern disks
-                    "-o", "altroot=" + altroot,  # Isolated mount point
+                    "-o", "altroot=" + str(altroot),  # Isolated mount point
                     "-O", "mountpoint=/",   # Root dataset mountpoint
                     "-O", "compression=on", # Common ZFS feature
                     "-O", "atime=off",      # Improve performance
@@ -422,6 +423,7 @@ class TestImageGenerator:
                 self.logger.error(f"Error creating ZFS pool: {e}")
                 # Attempt cleanup
                 self._run_command(["zpool", "destroy", "-f", pool_name], check=False)
+                shutil.rmtree(altroot, ignore_errors=True)
                 raise
                 
         else:
@@ -443,8 +445,7 @@ class TestImageGenerator:
         if fs_type == "zfs":
             # For ZFS, the filesystem should already be mounted at altroot
             # We'll just verify it's accessible
-            pool_name = "sbomtmp"
-            altroot = "/tmp/sbom_zfs_tmp"
+            altroot = self.zfs_altroot
             
             if not os.path.ismount(altroot):
                 raise RuntimeError(f"ZFS pool not mounted at expected location: {altroot}")

--- a/sbom-vm.py
+++ b/sbom-vm.py
@@ -6,16 +6,20 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
+import re
 import time
 import shutil
 import tempfile
 
 def setup_logging(image_path: Path) -> logging.Logger:
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    log_file = f"{timestamp}_{image_path.stem}.log"
+    log_dir = Path(os.environ.get("SBOM_VM_LOG_DIR", "."))
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / f"{timestamp}_{image_path.stem}.log"
     
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)
+    logger.handlers.clear()
     
     formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
     
@@ -34,36 +38,56 @@ def setup_logging(image_path: Path) -> logging.Logger:
 logger = None  # Will be initialized in main()
 
 class ImageMounter:
-    def __init__(self, image_path: str, mount_point: str = "/mnt/image_analysis"):
+    def __init__(self, image_path: str, mount_point: str = None):
         self.image_path = Path(image_path)
-        self.mount_point = Path(mount_point)
-        self.nbd_device = "/dev/nbd0"
+        self.mount_point = Path(mount_point) if mount_point else None
+        self.nbd_device = None
         self.mounted_partition = None
         self.temp_dir = None
         self.temp_image = None
+        self.imported_zfs_pool = None
 
     def parse_size(self, size_str):
-        """Parse size strings with units into numeric values."""
-        try:
-            size_str = str(size_str).strip().upper()
-            if 'GB' in size_str:
-                return float(size_str.rstrip('GB')) * 1024
-            elif 'MB' in size_str:
-                return float(size_str.rstrip('MB'))
-            elif 'KB' in size_str:
-                return float(size_str.rstrip('KB')) / 1024
-            else:
-                return float(size_str)
-        except (ValueError, AttributeError):
+        """Parse size strings with units into MiB."""
+        if size_str is None:
             return 0
+
+        match = re.fullmatch(r"\s*([0-9]+(?:\.[0-9]+)?)\s*([KMGT]?I?B?)?\s*", str(size_str), re.IGNORECASE)
+        if not match:
+            return 0
+
+        value = float(match.group(1))
+        unit = (match.group(2) or "MB").upper()
+        multipliers = {
+            "": 1,
+            "B": 1 / (1024 * 1024),
+            "K": 1 / 1024,
+            "KB": 1 / 1024,
+            "KIB": 1 / 1024,
+            "M": 1,
+            "MB": 1,
+            "MIB": 1,
+            "G": 1024,
+            "GB": 1024,
+            "GIB": 1024,
+            "T": 1024 * 1024,
+            "TB": 1024 * 1024,
+            "TIB": 1024 * 1024,
+        }
+        return value * multipliers.get(unit, 0)
 
     def _run_command(self, command: list, check: bool = True, **kwargs) -> subprocess.CompletedProcess:
         try:
-            result = subprocess.run(command, check=check, capture_output=True, text=True, **kwargs)
-            return result
+            run_kwargs = kwargs.copy()
+            has_redirect = "stdout" in run_kwargs or "stderr" in run_kwargs
+            run_kwargs.setdefault("text", not has_redirect)
+            if not has_redirect:
+                run_kwargs["capture_output"] = True
+            return subprocess.run(command, check=check, **run_kwargs)
         except subprocess.CalledProcessError as e:
             logger.error(f"Command failed: {' '.join(command)}")
-            logger.error(f"Error output: {e.stderr}")
+            if e.stderr:
+                logger.error(f"Error output: {e.stderr}")
             raise
 
     def _detect_image_format(self) -> str:
@@ -98,16 +122,18 @@ class ImageMounter:
     def _prepare_image(self) -> Path:
         """Prepare image for mounting, converting if necessary."""
         self.temp_dir = tempfile.mkdtemp(prefix='sbomvm_')
+        if self.mount_point is None:
+            self.mount_point = Path(tempfile.mkdtemp(prefix='sbomvm_mount_', dir=self.temp_dir))
         image_format = self._detect_image_format()
         
         if image_format == 'gzip':
             logger.info("Decompressing gzipped image")
             self.temp_image = Path(self.temp_dir) / f"{self.image_path.stem}.raw"
-            self._run_command(
-                ["gunzip", "-c", str(self.image_path)],
-                stdout=open(self.temp_image, 'wb'),
-                text=False
-            )
+            with open(self.temp_image, 'wb') as output:
+                self._run_command(
+                    ["gunzip", "-c", str(self.image_path)],
+                    stdout=output,
+                )
             return self.temp_image
             
         elif image_format in ['vmdk', 'vhd', 'vpc']:
@@ -129,9 +155,18 @@ class ImageMounter:
         self._run_command(["modprobe", "nbd", "max_part=8"])
         time.sleep(1)
 
+    def _find_free_nbd_device(self) -> str:
+        for device in sorted(Path("/dev").glob("nbd*")):
+            if device.name.startswith("nbd") and device.name[3:].isdigit():
+                result = self._run_command(["qemu-nbd", "--check", str(device)], check=False)
+                if result.returncode != 0:
+                    return str(device)
+        raise RuntimeError("No free /dev/nbd device found")
+
     def connect_image(self):
         prepared_image = self._prepare_image()
-        logger.info(f"Connecting image {prepared_image} to NBD device")
+        self.nbd_device = self._find_free_nbd_device()
+        logger.info(f"Connecting image {prepared_image} to NBD device {self.nbd_device}")
         self._run_command(["qemu-nbd", "--connect", self.nbd_device, str(prepared_image)])
         # Increase delay to allow NBD device to stabilize
         time.sleep(2)
@@ -297,6 +332,7 @@ class ImageMounter:
             "zpool", "import", "-f", "-d", zfs_partition,
             "-R", str(self.mount_point), "-o", "readonly=on", pool_name
         ])
+        self.imported_zfs_pool = pool_name
 
     def generate_sbom(self):
         # Get filesystem type
@@ -304,7 +340,7 @@ class ImageMounter:
             fs_type = self._run_command(
                 ["blkid", "-o", "value", "-s", "TYPE", self.mounted_partition]
             ).stdout.strip()
-        except:
+        except subprocess.CalledProcessError:
             fs_type = "unknown"
         
         # Extract partition device name
@@ -318,9 +354,9 @@ class ImageMounter:
         logger.info(f"Generating SBOM for mounted filesystem at {self.mount_point}")
         logger.info(f"Filesystem type: {fs_type}")
         
-        # Debug mount contents
-        self._run_command(["ls", "-la", str(self.mount_point)])
-        self._run_command(["mount"])
+        if os.environ.get("SBOM_VM_DEBUG_MOUNT"):
+            self._run_command(["ls", "-la", str(self.mount_point)])
+            self._run_command(["mount"])
         
         # Generate SBOM
         self._run_command([
@@ -335,23 +371,17 @@ class ImageMounter:
     def cleanup(self):
         logger.info("Starting cleanup")
         
-        # Export ZFS pools
-        try:
-            pools = self._run_command(["zpool", "list", "-H"], check=False)
-            if pools.returncode == 0 and pools.stdout.strip():
-                for pool in pools.stdout.strip().split('\n'):
-                    pool_name = pool.split()[0]
-                    logger.info(f"Exporting ZFS pool {pool_name}")
-                    self._run_command(["zpool", "export", pool_name], check=False)
-        except Exception as e:
-            logger.debug(f"Error during ZFS cleanup: {e}")
+        if self.imported_zfs_pool:
+            logger.info(f"Exporting ZFS pool {self.imported_zfs_pool}")
+            self._run_command(["zpool", "export", self.imported_zfs_pool], check=False)
 
-        if self.mount_point.is_mount():
+        if self.mount_point and self.mount_point.is_mount():
             logger.info(f"Unmounting {self.mount_point}")
             self._run_command(["umount", str(self.mount_point)], check=False)
         
-        logger.info("Disconnecting NBD device")
-        self._run_command(["qemu-nbd", "--disconnect", self.nbd_device], check=False)
+        if self.nbd_device:
+            logger.info("Disconnecting NBD device")
+            self._run_command(["qemu-nbd", "--disconnect", self.nbd_device], check=False)
         
         logger.info("Removing NBD kernel module")
         self._run_command(["rmmod", "nbd"], check=False)

--- a/tests/test_parse_size.py
+++ b/tests/test_parse_size.py
@@ -1,0 +1,33 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "sbom-vm.py"
+SPEC = importlib.util.spec_from_file_location("sbom_vm", MODULE_PATH)
+sbom_vm = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(sbom_vm)
+
+
+class ParseSizeTest(unittest.TestCase):
+    def setUp(self):
+        self.mounter = sbom_vm.ImageMounter("dummy.qcow2")
+
+    def test_parses_standard_units_as_mib(self):
+        self.assertEqual(self.mounter.parse_size("1GB"), 1024)
+        self.assertEqual(self.mounter.parse_size("512MB"), 512)
+        self.assertEqual(self.mounter.parse_size("1024KB"), 1)
+
+    def test_parses_parted_style_units(self):
+        self.assertEqual(self.mounter.parse_size("1.5GB"), 1536)
+        self.assertEqual(self.mounter.parse_size("2048kB"), 2)
+        self.assertEqual(self.mounter.parse_size("2MiB"), 2)
+
+    def test_rejects_invalid_values(self):
+        self.assertEqual(self.mounter.parse_size(None), 0)
+        self.assertEqual(self.mounter.parse_size("not-a-size"), 0)
+        self.assertEqual(self.mounter.parse_size("12XB"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix the recurring sbom-vm safety bugs repo-assist kept rediscovering: parse_size suffix parsing, gzip file handle handling, subprocess stdout/stderr overrides, unique NBD selection, temporary mount directory use, debug mount command gating, targeted ZFS cleanup, and configurable log directory
- fix test image generator cleanup issues: replace mktemp, avoid process-wide chdir, and use per-run ZFS pool/altroot names
- add CONTRIBUTING.md, a minimal CI workflow, and focused unit tests for parse_size
- disable unattended scheduled repo-assist runs and lower its output limits to prevent duplicate issue churn while keeping manual/slash-command use available

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile sbom-vm.py generate-test-images.py tests/test_parse_size.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests
- git diff --check

Closes #1
Closes #2
Closes #10
Closes #11
Closes #12
Closes #13
Closes #14
Closes #15
Closes #16
Closes #17
Closes #18
Closes #19

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates cleanup and safety fixes across sbom-vm and the test image generator, adds basic CI and tests, and tames `repo-assist` automation to prevent noisy duplicates.

- **Bug Fixes**
  - sbom-vm: robust size parsing (KB/MB/GB/KiB/GiB → MiB), safe gzip decompression, respect subprocess stdout/stderr overrides, auto-select a free NBD device, use a per-run temp mount dir, gate mount debugging behind `SBOM_VM_DEBUG_MOUNT`, export only the imported ZFS pool, and support `SBOM_VM_LOG_DIR` for logs.
  - Test image generator: replace `mktemp` with secure temp file creation, avoid process-wide `chdir`, use per-run ZFS pool/altroot with proper cleanup.
  - `repo-assist`: disable scheduled runs and reduce output limits (max 1) to stop duplicate issue churn while keeping manual use available.

- **New Features**
  - Add `CONTRIBUTING.md`.
  - Minimal CI (`.github/workflows/ci.yml`) to compile scripts and run unit tests.
  - Focused unit tests for `parse_size`.

<sup>Written for commit d1a304d3b28d8f0cb0b03a453378e76711eedda1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/popey/sbom-vm/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

