### PR TITLE
fix: replace bare except with except Exception in generate_sbom

### DIFF
--- a/sbom-vm.py
+++ b/sbom-vm.py
@@ -304,7 +304,7 @@ class ImageMounter:
             fs_type = self._run_command(
                 ["blkid", "-o", "value", "-s", "TYPE", self.mounted_partition]
             ).stdout.strip()
-        except:
+        except Exception:
             fs_type = "unknown"
         
         # Extract partition device name


### PR DESCRIPTION
Replaces bare `except:` with `except Exception:` to avoid catching KeyboardInterrupt and SystemExit.

Closes #11

---

Support my work: https://buymeacoffee.com/muhamedfazalps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit exception handling in `generate_sbom` by replacing a bare `except:` with `except Exception` during filesystem type detection. This prevents swallowing `KeyboardInterrupt` and `SystemExit` while keeping the fallback to "unknown" on failure.

<sup>Written for commit 6aa8571de1342d3087452c36dad541a9c70b7088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/popey/sbom-vm/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

